### PR TITLE
Fix 264. Incorrect affinity parameter

### DIFF
--- a/tutorials/synthetic-retrieval-evaluation/DeDup.py
+++ b/tutorials/synthetic-retrieval-evaluation/DeDup.py
@@ -32,7 +32,6 @@ class Dedup:
 
         agg_clustering = AgglomerativeClustering(
             n_clusters=None,
-            affinity="precomputed",
             linkage="complete",
             distance_threshold=threshold,
         )


### PR DESCRIPTION
Fix #264. Scikit-learn is not expecting anymore the "affinity parameter"

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
